### PR TITLE
Add cross platform system report tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# work_that_processor
+# System Report
+
+System Report is a small cross platform tool to gather information about the
+current machine. It collects CPU, GPU, RAM, storage and software information
+and stores it in a timestamped JSON file in the user's Downloads directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "system_report"
+version = "0.1.0"
+description = "Cross platform system information gathering tool"
+readme = "README.md"
+authors = [{name = "Auto"}]
+requires-python = ">=3.8"
+
+[project.scripts]
+system-report = "system_report.cli:main"

--- a/system_report/__init__.py
+++ b/system_report/__init__.py
@@ -1,0 +1,6 @@
+"""System Report package."""
+
+from .gather import gather_all
+from .save import save_report
+
+__all__ = ["gather_all", "save_report"]

--- a/system_report/cli.py
+++ b/system_report/cli.py
@@ -1,0 +1,12 @@
+from .gather import gather_all
+from .save import save_report
+
+
+def main():
+    data = gather_all()
+    path = save_report(data)
+    print(f"Report saved to {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/system_report/gather.py
+++ b/system_report/gather.py
@@ -1,0 +1,114 @@
+import json
+import platform
+import subprocess
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - fallback when psutil is missing
+    psutil = None
+
+try:
+    import cpuinfo  # type: ignore
+except ImportError:  # pragma: no cover - fallback
+    cpuinfo = None
+
+try:
+    import GPUtil  # type: ignore
+except ImportError:  # pragma: no cover
+    GPUtil = None
+
+def _run_cmd(cmd):
+    try:
+        result = subprocess.check_output(cmd, shell=True, text=True)
+        return result.strip()
+    except Exception:
+        return ""
+
+def get_cpu_info():
+    info = {
+        "architecture": platform.machine(),
+        "count": psutil.cpu_count(logical=False) if psutil else None,
+        "count_logical": psutil.cpu_count() if psutil else None,
+    }
+    if cpuinfo:
+        data = cpuinfo.get_cpu_info()
+        info.update({
+            "brand": data.get("brand_raw"),
+            "hz_advertised": data.get("hz_advertised_friendly"),
+            "l2_cache_size": data.get("l2_cache_size"),
+            "l3_cache_size": data.get("l3_cache_size"),
+            "arch": data.get("arch_string_raw"),
+            "flags": data.get("flags"),
+        })
+    return info
+
+def get_gpu_info():
+    gpus = []
+    if GPUtil:
+        for gpu in GPUtil.getGPUs():
+            gpus.append({
+                "name": gpu.name,
+                "total_memory": gpu.memoryTotal,
+                "uuid": gpu.uuid,
+                "driver": gpu.driver,
+            })
+    return gpus
+
+def get_ram_info():
+    if not psutil:
+        return {}
+    mem = psutil.virtual_memory()
+    return {
+        "total": mem.total,
+        "available": mem.available,
+    }
+
+def get_storage_info():
+    if not psutil:
+        return []
+    disks = []
+    for part in psutil.disk_partitions():
+        usage = psutil.disk_usage(part.mountpoint)
+        disks.append({
+            "device": part.device,
+            "mountpoint": part.mountpoint,
+            "fstype": part.fstype,
+            "total": usage.total,
+            "free": usage.free,
+        })
+    return disks
+
+def get_installed_software():
+    softwares = []
+    if platform.system() == "Windows":
+        cmd = "wmic product get name,version"
+        out = _run_cmd(cmd)
+        for line in out.splitlines()[1:]:
+            if line.strip():
+                softwares.append(line.strip())
+    elif shutil.which("dpkg"):
+        out = _run_cmd("dpkg -l | awk '{print $2" " $3}'")
+        softwares = out.splitlines()
+    elif shutil.which("rpm"):
+        out = _run_cmd("rpm -qa")
+        softwares = out.splitlines()
+    return softwares
+
+def docker_or_podman_installed():
+    return shutil.which("docker") is not None or shutil.which("podman") is not None
+
+def gather_all():
+    data = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "platform": platform.platform(),
+        "cpu": get_cpu_info(),
+        "gpu": get_gpu_info(),
+        "ram": get_ram_info(),
+        "storage": get_storage_info(),
+        "installed_software": get_installed_software(),
+        "docker_or_podman": docker_or_podman_installed(),
+    }
+    return data

--- a/system_report/save.py
+++ b/system_report/save.py
@@ -1,0 +1,27 @@
+import json
+from datetime import datetime
+from pathlib import Path
+import platform
+
+
+def default_path() -> Path:
+    home = Path.home()
+    if platform.system() == "Windows":
+        return home / "Downloads" / "system_report.json"
+    else:
+        return home / "Downloads" / "system_report.json"
+
+
+def save_report(data: dict, path: Path = None) -> Path:
+    if path is None:
+        path = default_path()
+    if path.exists():
+        with path.open("r", encoding="utf-8") as fh:
+            existing = json.load(fh)
+    else:
+        existing = {}
+    timestamp = data.get("timestamp", datetime.utcnow().isoformat())
+    existing[timestamp] = data
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(existing, fh, indent=2)
+    return path

--- a/system_report/tests/test_cli.py
+++ b/system_report/tests/test_cli.py
@@ -1,0 +1,7 @@
+from system_report.cli import main
+
+
+def test_cli_runs(tmp_path, monkeypatch):
+    monkeypatch.setattr('system_report.save.default_path', lambda: tmp_path / 'out.json')
+    main()
+    assert (tmp_path / 'out.json').exists()

--- a/system_report/tests/test_gather.py
+++ b/system_report/tests/test_gather.py
@@ -1,0 +1,19 @@
+import json
+from system_report import gather_all, save_report
+
+
+def test_gather_all_returns_dict(monkeypatch):
+    data = gather_all()
+    assert isinstance(data, dict)
+    assert 'cpu' in data
+    assert 'storage' in data
+
+
+def test_save_report(tmp_path):
+    data = gather_all()
+    path = tmp_path / "report.json"
+    save_report(data, path)
+    assert path.exists()
+    with path.open() as fh:
+        stored = json.load(fh)
+    assert list(stored.keys())[0] == data['timestamp']


### PR DESCRIPTION
## Summary
- create small `system_report` Python package
- gather CPU, GPU, RAM, storage and software information
- save reports as timestamped JSON in user's Downloads folder
- expose command line interface `system-report`
- add basic unit tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f803c21d4832e9b945100c17e25e3