### PR TITLE
Enable GitHub CI for unit tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Python package
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@
 System Report is a small cross platform tool to gather information about the
 current machine. It collects CPU, GPU, RAM, storage and software information
 and stores it in a timestamped JSON file in the user's Downloads directory.
+
+## Running
+
+Install the package in editable mode and run the CLI:
+
+```bash
+pip install -e .
+system-report
+```
+
+This will create or update a `system_report.json` file in your `~/Downloads`
+directory.
+
+## Tests
+
+Unit tests are located under `system_report/tests`. Install the package and run
+`pytest`:
+
+```bash
+pip install -e .
+pytest -q
+```
+
+A GitHub Actions workflow in `.github/workflows/python-tests.yml` automatically
+executes these tests on pushes and pull requests.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs dependencies and runs pytest
- document how to run the tool and tests locally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f82b56360832eba0d60b427681499