### PR TITLE
Fix CLI error when Downloads directory is missing

### DIFF
--- a/system_report/save.py
+++ b/system_report/save.py
@@ -15,6 +15,8 @@ def default_path() -> Path:
 def save_report(data: dict, path: Path = None) -> Path:
     if path is None:
         path = default_path()
+    # ensure the directory exists so we don't fail if ~/Downloads is missing
+    path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         with path.open("r", encoding="utf-8") as fh:
             existing = json.load(fh)


### PR DESCRIPTION
## Summary
- ensure the output directory exists in `save_report`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400fa961ec832e85bcda01f87fd5c8